### PR TITLE
Sea Salt alternative reference fix

### DIFF
--- a/Gamma_Analysis.py
+++ b/Gamma_Analysis.py
@@ -39,18 +39,14 @@ def absolute_efficiency(energy, coeffs=EFFICIENCY_CAL_COEFFS):
                           coeffs[0]))
     return efficiency
 
-
-def emission_rate(net_area, livetime):
+def emission_rate(net_area, efficiency, livetime):
     """
     this function returns the emission rate of gammas per second
     alongside its uncertainty.
     """
-    # Note: The emission rate calculation excludes the efficiency in the
-    #       denominator because the emission rates of the sample and the
-    #       reference are divided eventually in the analysis.
-    emission_rate = [net_area[0]/livetime, net_area[1]/livetime]
-
-    return emission_rate
+    emission_rate = [net_area[0]/(efficiency*livetime),
+                     net_area[1]/(efficiency*livetime)]
+return emission_rate
 
 
 def isotope_activity(isotope, emission_rates, emission_uncertainty):
@@ -352,7 +348,7 @@ def analyze_isotope(measurement, background, reference, isotope):
         sample_comparison = ref.soil_reference
     # ROI sub_regions handled in ROI_Maker.
 
-    # isotope_efficiency = absolute_efficiency(isotope.list_sig_g_e)
+    isotope_efficiency = absolute_efficiency(isotope.list_sig_g_e)
 
     isotope_energy = isotope.list_sig_g_e
     gamma_emission = []
@@ -375,6 +371,7 @@ def analyze_isotope(measurement, background, reference, isotope):
                                                  reference.livetime,
                                                  background.livetime)
             reference_emission = emission_rate(reference_area,
+                                               isotope_efficiency,
                                                reference.livetime)
             ref_emission.append(reference_emission[0])
             ref_uncertainty.append(reference_emission[1])
@@ -388,7 +385,7 @@ def analyze_isotope(measurement, background, reference, isotope):
                                        background_peak,
                                        measurement.livetime,
                                        background.livetime)
-        peak_emission = emission_rate(net_area,
+        peak_emission = emission_rate(net_area, isotope_efficiency,
                                       measurement.livetime)
 
         gamma_emission.append(peak_emission[0])

--- a/Gamma_Analysis.py
+++ b/Gamma_Analysis.py
@@ -128,8 +128,8 @@ def isotope_concentration(isotope, reference, sample_activity,
     not_in_dirt = ['Cs134', 'Cs137', 'Co60', 'Pb210']
     ref_specific_activity = reference_activity[0] / reference.mass
 
-    if type(reference) is ref.base_reference_class():
-    elif type(reference) is ref.petri_reference_class():
+    if isinstance(reference, PetriReference):
+    else:
 
     if isotope.symbol + str(isotope.mass_number) in not_in_dirt:
         ref_conc_specact_ratio = 1
@@ -346,10 +346,10 @@ def analyze_isotope(measurement, background, reference, isotope):
     Calculate concentration for one isotope in one measurement,
     using background spectrum and reference spectrum.
     """
-    if type(reference) is ref.base_reference_class():
-        sample_comparison = ref.soil_reference
-    elif type(reference) is ref.petri_reference_class():
+    if isinstance(reference, PetriReference):
         sample_comparison = ref.petri_reference
+    else:
+        sample_comparison = ref.soil_reference
     # ROI sub_regions handled in ROI_Maker.
 
     # isotope_efficiency = absolute_efficiency(isotope.list_sig_g_e)
@@ -368,7 +368,7 @@ def analyze_isotope(measurement, background, reference, isotope):
         # Only find the reference peak identifier, peak area, and emission
         # if the reference is the S5F reference spectrum. Ignore if the
         # reference is the Petri reference class.
-        if type(reference) is ref.base_reference_class():
+        if isinstance(reference, PetriReference):
             reference_peak = peak_measurement(reference, energy)
             reference_area = background_subtract(reference_peak,
                                                  background_peak,
@@ -381,7 +381,7 @@ def analyze_isotope(measurement, background, reference, isotope):
             reference_activity = isotope_activity(isotope,
                                                   ref_emission,
                                                   ref_uncertainty)
-        elif type(reference) is ref.petri_reference_class():
+        else:
             reference_activity = sample_comparison.ref_spec_ct_rate
 
         net_area = background_subtract(sample_net_area,

--- a/Gamma_Reference.py
+++ b/Gamma_Reference.py
@@ -18,15 +18,15 @@ class petri_reference_class(base_reference_class):
     """
     def spec_count_rate(self, mass, ref_concentration, ref_concentration_error,
                  conversion, ref_specific_count_rate):
-        self.ref_spec_ct_rate = ref_specific_activity
+        self.ref_spec_ct_rate = ref_specific_count_rate
 
 # Create a list of samples that uses an alternate reference.
 alt_ref_samples = ['UCB027']
 # Define the mass for the Petri soil reference sample.
 dirt_petri_mass = 1.18360
-petri_specific_count_rate = [2.15E-01, 9.35E-03, 2.17E-02, 1.05E-02, 1.75E-02,
-                             1.56E-02, 7.27E-02, 8.28E-03, 8.56E-03, 4.11E-02,
-                             5.25E-02, 3.10E-02, 1.07E-02, 1.50E-02]
+petri_specific_count_rate = [3.11E-04, 2.15E-01, 9.35E-03, 2.17E-02, 1.05E-02,
+                             1.75E-02, 1.56E-02, 7.27E-02, 8.28E-03, 8.56E-03,
+                             4.11E-02, 5.25E-02, 3.10E-02, 1.07E-02, 1.50E-02]
 
 # Define the mass for the S5F soil reference sample.
 dirt_S5F_mass = 1.19300

--- a/Gamma_Reference.py
+++ b/Gamma_Reference.py
@@ -1,4 +1,4 @@
-class base_reference_class(object):
+class ReferenceBase(object):
     """
     Generates a reference object that contains a reference mass and
     concentrations. Mass is in kg and concentrations are in percent for
@@ -12,7 +12,7 @@ class base_reference_class(object):
         self.ref_concentration_error = ref_concentration_error
         self.conversion = conversion
 
-class petri_reference_class(base_reference_class):
+class PetriReference(ReferenceBase):
     """
     Uses the Petri dish sample data as the reference.
     """
@@ -52,8 +52,8 @@ dirt_concentrations_uncertainty = [dirt_k_40_unc, dirt_bi_214_unc,
                                    dirt_tl_208_unc, dirt_ac_228_unc,
                                    dirt_pb_212_unc]
 dirt_conversions = [309.6, 12.3, 4.07]
-soil_reference = base_reference_class(dirt_S5F_mass, dirt_concentrations,
+soil_reference = ReferenceBase(dirt_S5F_mass, dirt_concentrations,
                            dirt_concentrations_uncertainty, dirt_conversions)
-petri_reference = petri_reference_class(dirt_petri_mass, dirt_concentrations,
+petri_reference = PetriReference(dirt_petri_mass, dirt_concentrations,
                            dirt_concentrations_uncertainty, dirt_conversions,
                            petri_specific_activity)

--- a/Gamma_Reference.py
+++ b/Gamma_Reference.py
@@ -1,59 +1,205 @@
-class base_reference_class(object):
-    """
-    Generates a reference object that contains a reference mass and
-    concentrations. Mass is in kg and concentrations are in percent for
-    K-40 and ppm for the rest. Conversions are currently unknown in their
-    origin and derivation.
-    """
-    def __init__(self, mass, ref_concentration, ref_concentration_error,
-                 conversion):
-        self.mass = mass
-        self.ref_concentration = ref_concentration
-        self.ref_concentration_error = ref_concentration_error
-        self.conversion = conversion
+import numpy as np
+import peakutils
+import pandas as pd
+import shutil as sh
+import fileinput
+import SPEFile
+import os
 
-class petri_reference_class(base_reference_class):
+energy_list = [351.93, 583.19, 609.31, 911.20, 1460.82, 1764.49,
+               2614.51]
+cal_headers = [351.93, 583.19, 609.31, 911.20, 1460.82, 1764.49,
+               2614.51, 'Output']
+
+def acquire_files():
     """
-    Uses the Petri dish sample data as the reference.
+    acquire_files gathers all the .Spe file in the current file directory and
+    returns a list containing all .Spe files.
     """
-    def spec_count_rate(self, mass, ref_concentration, ref_concentration_error,
-                 conversion, ref_specific_count_rate):
-        self.ref_spec_ct_rate = ref_specific_count_rate
+    sample_measurements = []
+    recal_names = []
+    dir_path = os.getcwd()
+    for filename in os.listdir(dir_path):
+        if filename.lower().endswith(".spe"):
+            # Ignore the background and reference spectra
+            if filename == "USS_Independence_Background.Spe":
+                pass
+            elif filename == "UCB018_Soil_Sample010_2.Spe":
+                pass
+            else:
+                if '_recal.Spe' in filename:
+                    recal_names.append(filename)
+                sample_measurements.append(filename)
 
-# Create a list of samples that uses an alternate reference.
-alt_ref_samples = ['UCB027']
-# Define the mass for the Petri soil reference sample.
-dirt_petri_mass = 1.18360
-petri_specific_count_rate = [3.11E-04, 2.15E-01, 9.35E-03, 2.17E-02, 1.05E-02,
-                             1.75E-02, 1.56E-02, 7.27E-02, 8.28E-03, 8.56E-03,
-                             4.11E-02, 5.25E-02, 3.10E-02, 1.07E-02, 1.50E-02]
+    sample_measurements.sort()
 
-# Define the mass for the S5F soil reference sample.
-dirt_S5F_mass = 1.19300
-dirt_k_40 = 2.57
-dirt_bi_214 = 1.97
-dirt_pb_214 = 1.97
-dirt_th_234 = 2.26
-dirt_tl_208 = 5.08
-dirt_ac_228 = 5.43
-dirt_pb_212 = 5.08
+    print("recal_names: ", recal_names, '\n\n')
 
-dirt_k_40_unc = 0.01
-dirt_bi_214_unc = 0.02
-dirt_pb_214_unc = 0.02
-dirt_th_234_unc = 0.07
-dirt_tl_208_unc = 0.05
-dirt_ac_228_unc = 0.07
-dirt_pb_212_unc = 0.05
-dirt_concentrations = [dirt_k_40, dirt_bi_214, dirt_pb_214, dirt_th_234,
-                       dirt_tl_208, dirt_ac_228, dirt_pb_212]
-dirt_concentrations_uncertainty = [dirt_k_40_unc, dirt_bi_214_unc,
-                                   dirt_pb_214_unc, dirt_th_234_unc,
-                                   dirt_tl_208_unc, dirt_ac_228_unc,
-                                   dirt_pb_212_unc]
-dirt_conversions = [309.6, 12.3, 4.07]
-soil_reference = base_reference_class(dirt_S5F_mass, dirt_concentrations,
-                           dirt_concentrations_uncertainty, dirt_conversions)
-petri_reference = petri_reference_class(dirt_petri_mass, dirt_concentrations,
-                           dirt_concentrations_uncertainty, dirt_conversions,
-                           petri_specific_activity)
+    for recal_name in recal_names:
+        recal_focus = recal_name.replace('_recal', '')
+
+        print(recal_focus)
+
+        if recal_focus in sample_measurements:
+            sample_measurements.remove(recal_focus)
+
+    sample_names = [os.path.splitext(sample_measurements[i])
+                    [0].replace("_", " ")
+                    for i in np.arange(len(sample_measurements))]
+
+    print("sample_names: ", sample_names, '\n\n')
+    print("sample_measurements: ", sample_measurements, '\n\n')
+
+    return sample_measurements, sample_names
+
+
+def calibration_check(spectrum):
+    '''
+    calibration_check will search for certain peaks that are expected to occur
+    in every measured spectra. The energies it searches for are based on peaks
+    that occur in background radiation. Once these peaks are found, it
+    compares the energy of that peak to the actual energy the peak should be
+    at. This check is based on expected detector resolution and if the energy
+    deviates to far from the expected value (if beyond half a FWHM), then
+    calibration_check sends a message indicating a fix is needed. Only Spectra
+    are taken as input.
+    '''
+    E0 = spectrum.energy_cal[0]
+    Eslope = spectrum.energy_cal[1]
+    energy_axis = E0 + Eslope*spectrum.channel
+
+    peak_channel = []
+    found_energy = []
+    offsets = []
+    skip = 0
+    fix = 0
+    for energy in energy_list:
+        # rough estimate of fwhm.
+        fwhm = 0.05*energy**0.5
+        energy_range = 0.015*energy
+
+        # peak gross area
+
+        start_region = np.flatnonzero(energy_axis > energy - energy_range)[0]
+
+        end_region = np.flatnonzero(energy_axis > energy + energy_range)[0]
+        y = spectrum.data[start_region:end_region]
+        indexes = peakutils.indexes(y, thres=0.5, min_dist=4)
+        tallest_peak = []
+        if indexes.size == 0:
+            print('peak not found')
+            offsets.append(np.nan)
+            skip += 1
+        else:
+            for i in range(indexes.size):
+                spot = spectrum.data[indexes[i]+start_region]
+                tallest_peak.append(spot)
+            indexes = indexes[np.argmax(tallest_peak)]
+            peak_channel.append(int(indexes+start_region))
+            found_energy.append(energy)
+            difference = abs((energy -
+                              float(energy_axis[int(indexes+start_region)])))
+            offsets.append(difference)
+            if difference > 0.5*fwhm:
+                fix += 1
+    if skip > 4:
+        message = 'error'
+    elif fix >= 4:
+        message = 'fix'
+    else:
+        message = 'fine'
+    offsets.append(message)
+    return(peak_channel, found_energy, message, offsets)
+
+
+def calibration_correction(measurement, channel, energy):
+    """
+    calibration_correction implements a corrected energy calibration based
+    on the array of channels and energies given as input. It performs a
+    least squares regression fit of the channels and energies and implements
+    the new energy calibration in a newly generated .Spe file. The new
+    spectra file will contain the same information with only the old
+    calibration changed.
+    """
+    cal_file = sh.copyfile(measurement, os.path.splitext(measurement)[0] +
+                           '_recal.Spe')
+    fix_measurement = SPEFile.SPEFile(cal_file)
+    fix_measurement.read()
+    old_cal = (str(float(fix_measurement.energy_cal[0])) + ' ' +
+               str(float(fix_measurement.energy_cal[1])))
+
+    a_matrix = np.vstack([channel, np.ones(len(channel))]).T
+    calibration_line = np.linalg.lstsq(a_matrix, energy)
+
+    e0 = float(calibration_line[0][1])
+    eslope = float(calibration_line[0][0])
+    new_cal = str(float(e0)) + ' ' + str(float(eslope))
+    with fileinput.FileInput(cal_file, inplace=1) as file:
+        for line in file:
+            print(line.replace(old_cal, new_cal).rstrip())
+    return(cal_file)
+
+
+def recalibrate(files):
+    cal_error = []
+    double_check = []
+    cal_offsets = []
+
+    for sample in files:
+        if '_recal.Spe' in sample.lower():
+            double_check.append(sample)
+            pass
+        else:
+            measurement = SPEFile.SPEFile(sample)
+            measurement.read()
+            [channel, energy, status, offsets] = calibration_check(measurement)
+            cal_offsets.append(offsets)
+            if status == 'fix':
+                print(('\nFixing calibration for %s \n' % sample))
+                cal_file = calibration_correction(sample, channel,
+                                                  energy)
+                double_check.append(cal_file)
+            elif status == 'error':
+                cal_error.append(sample)
+    for check in double_check:
+        Recal = SPEFile.SPEFile(check)
+        Recal.read()
+        status = calibration_check(Recal)[2]
+        if status == 'fix':
+            cal_error.append(check.replace('_recal.Spe', '.Spe'))
+    if cal_error == []:
+        pass
+    else:
+        with open('Error_Cal.txt', 'w') as file:
+            file.writelines('Check calibration in %s \n' % error for error in
+                            cal_error)
+    # for file in files:
+    #     if '_recal.Spe' in file:
+    #         files.remove(file)
+
+    files_updated = [os.path.splitext(files[i])
+                     [0].replace("_recal", "")
+                     for i in np.arange(len(files))]
+
+    calibration_table(files_updated, cal_headers, cal_offsets)
+
+
+def calibration_table(samples, headers, offsets):
+
+    cal_results = {}
+    for i in range(len(samples)):
+
+        cal_results[samples[i]] = np.array(offsets[i])
+
+    cal_frame = pd.DataFrame(cal_results, index=headers)
+    cal_frame = cal_frame.T
+    cal_frame.index.name = 'Filename'
+    cal_frame.to_csv('calibration_results.csv')
+
+
+def main():
+    sample_measurements, _ = acquire_files()
+    recalibrate(sample_measurements)
+
+if __name__ == '__main__':
+    main()

--- a/Gamma_Reference.py
+++ b/Gamma_Reference.py
@@ -1,205 +1,59 @@
-import numpy as np
-import peakutils
-import pandas as pd
-import shutil as sh
-import fileinput
-import SPEFile
-import os
-
-energy_list = [351.93, 583.19, 609.31, 911.20, 1460.82, 1764.49,
-               2614.51]
-cal_headers = [351.93, 583.19, 609.31, 911.20, 1460.82, 1764.49,
-               2614.51, 'Output']
-
-def acquire_files():
+class base_reference_class(object):
     """
-    acquire_files gathers all the .Spe file in the current file directory and
-    returns a list containing all .Spe files.
+    Generates a reference object that contains a reference mass and
+    concentrations. Mass is in kg and concentrations are in percent for
+    K-40 and ppm for the rest. Conversions are currently unknown in their
+    origin and derivation.
     """
-    sample_measurements = []
-    recal_names = []
-    dir_path = os.getcwd()
-    for filename in os.listdir(dir_path):
-        if filename.lower().endswith(".spe"):
-            # Ignore the background and reference spectra
-            if filename == "USS_Independence_Background.Spe":
-                pass
-            elif filename == "UCB018_Soil_Sample010_2.Spe":
-                pass
-            else:
-                if '_recal.Spe' in filename:
-                    recal_names.append(filename)
-                sample_measurements.append(filename)
+    def __init__(self, mass, ref_concentration, ref_concentration_error,
+                 conversion):
+        self.mass = mass
+        self.ref_concentration = ref_concentration
+        self.ref_concentration_error = ref_concentration_error
+        self.conversion = conversion
 
-    sample_measurements.sort()
-
-    print("recal_names: ", recal_names, '\n\n')
-
-    for recal_name in recal_names:
-        recal_focus = recal_name.replace('_recal', '')
-
-        print(recal_focus)
-
-        if recal_focus in sample_measurements:
-            sample_measurements.remove(recal_focus)
-
-    sample_names = [os.path.splitext(sample_measurements[i])
-                    [0].replace("_", " ")
-                    for i in np.arange(len(sample_measurements))]
-
-    print("sample_names: ", sample_names, '\n\n')
-    print("sample_measurements: ", sample_measurements, '\n\n')
-
-    return sample_measurements, sample_names
-
-
-def calibration_check(spectrum):
-    '''
-    calibration_check will search for certain peaks that are expected to occur
-    in every measured spectra. The energies it searches for are based on peaks
-    that occur in background radiation. Once these peaks are found, it
-    compares the energy of that peak to the actual energy the peak should be
-    at. This check is based on expected detector resolution and if the energy
-    deviates to far from the expected value (if beyond half a FWHM), then
-    calibration_check sends a message indicating a fix is needed. Only Spectra
-    are taken as input.
-    '''
-    E0 = spectrum.energy_cal[0]
-    Eslope = spectrum.energy_cal[1]
-    energy_axis = E0 + Eslope*spectrum.channel
-
-    peak_channel = []
-    found_energy = []
-    offsets = []
-    skip = 0
-    fix = 0
-    for energy in energy_list:
-        # rough estimate of fwhm.
-        fwhm = 0.05*energy**0.5
-        energy_range = 0.015*energy
-
-        # peak gross area
-
-        start_region = np.flatnonzero(energy_axis > energy - energy_range)[0]
-
-        end_region = np.flatnonzero(energy_axis > energy + energy_range)[0]
-        y = spectrum.data[start_region:end_region]
-        indexes = peakutils.indexes(y, thres=0.5, min_dist=4)
-        tallest_peak = []
-        if indexes.size == 0:
-            print('peak not found')
-            offsets.append(np.nan)
-            skip += 1
-        else:
-            for i in range(indexes.size):
-                spot = spectrum.data[indexes[i]+start_region]
-                tallest_peak.append(spot)
-            indexes = indexes[np.argmax(tallest_peak)]
-            peak_channel.append(int(indexes+start_region))
-            found_energy.append(energy)
-            difference = abs((energy -
-                              float(energy_axis[int(indexes+start_region)])))
-            offsets.append(difference)
-            if difference > 0.5*fwhm:
-                fix += 1
-    if skip > 4:
-        message = 'error'
-    elif fix >= 4:
-        message = 'fix'
-    else:
-        message = 'fine'
-    offsets.append(message)
-    return(peak_channel, found_energy, message, offsets)
-
-
-def calibration_correction(measurement, channel, energy):
+class petri_reference_class(base_reference_class):
     """
-    calibration_correction implements a corrected energy calibration based
-    on the array of channels and energies given as input. It performs a
-    least squares regression fit of the channels and energies and implements
-    the new energy calibration in a newly generated .Spe file. The new
-    spectra file will contain the same information with only the old
-    calibration changed.
+    Uses the Petri dish sample data as the reference.
     """
-    cal_file = sh.copyfile(measurement, os.path.splitext(measurement)[0] +
-                           '_recal.Spe')
-    fix_measurement = SPEFile.SPEFile(cal_file)
-    fix_measurement.read()
-    old_cal = (str(float(fix_measurement.energy_cal[0])) + ' ' +
-               str(float(fix_measurement.energy_cal[1])))
+    def spec_count_rate(self, mass, ref_concentration, ref_concentration_error,
+                 conversion, ref_specific_count_rate):
+        self.ref_spec_ct_rate = ref_specific_count_rate
 
-    a_matrix = np.vstack([channel, np.ones(len(channel))]).T
-    calibration_line = np.linalg.lstsq(a_matrix, energy)
+# Create a list of samples that uses an alternate reference.
+alt_ref_samples = ['UCB027']
+# Define the mass for the Petri soil reference sample.
+dirt_petri_mass = 1.18360
+petri_specific_count_rate = [3.11E-04, 2.15E-01, 9.35E-03, 2.17E-02, 1.05E-02,
+                             1.75E-02, 1.56E-02, 7.27E-02, 8.28E-03, 8.56E-03,
+                             4.11E-02, 5.25E-02, 3.10E-02, 1.07E-02, 1.50E-02]
 
-    e0 = float(calibration_line[0][1])
-    eslope = float(calibration_line[0][0])
-    new_cal = str(float(e0)) + ' ' + str(float(eslope))
-    with fileinput.FileInput(cal_file, inplace=1) as file:
-        for line in file:
-            print(line.replace(old_cal, new_cal).rstrip())
-    return(cal_file)
+# Define the mass for the S5F soil reference sample.
+dirt_S5F_mass = 1.19300
+dirt_k_40 = 2.57
+dirt_bi_214 = 1.97
+dirt_pb_214 = 1.97
+dirt_th_234 = 2.26
+dirt_tl_208 = 5.08
+dirt_ac_228 = 5.43
+dirt_pb_212 = 5.08
 
-
-def recalibrate(files):
-    cal_error = []
-    double_check = []
-    cal_offsets = []
-
-    for sample in files:
-        if '_recal.Spe' in sample.lower():
-            double_check.append(sample)
-            pass
-        else:
-            measurement = SPEFile.SPEFile(sample)
-            measurement.read()
-            [channel, energy, status, offsets] = calibration_check(measurement)
-            cal_offsets.append(offsets)
-            if status == 'fix':
-                print(('\nFixing calibration for %s \n' % sample))
-                cal_file = calibration_correction(sample, channel,
-                                                  energy)
-                double_check.append(cal_file)
-            elif status == 'error':
-                cal_error.append(sample)
-    for check in double_check:
-        Recal = SPEFile.SPEFile(check)
-        Recal.read()
-        status = calibration_check(Recal)[2]
-        if status == 'fix':
-            cal_error.append(check.replace('_recal.Spe', '.Spe'))
-    if cal_error == []:
-        pass
-    else:
-        with open('Error_Cal.txt', 'w') as file:
-            file.writelines('Check calibration in %s \n' % error for error in
-                            cal_error)
-    # for file in files:
-    #     if '_recal.Spe' in file:
-    #         files.remove(file)
-
-    files_updated = [os.path.splitext(files[i])
-                     [0].replace("_recal", "")
-                     for i in np.arange(len(files))]
-
-    calibration_table(files_updated, cal_headers, cal_offsets)
-
-
-def calibration_table(samples, headers, offsets):
-
-    cal_results = {}
-    for i in range(len(samples)):
-
-        cal_results[samples[i]] = np.array(offsets[i])
-
-    cal_frame = pd.DataFrame(cal_results, index=headers)
-    cal_frame = cal_frame.T
-    cal_frame.index.name = 'Filename'
-    cal_frame.to_csv('calibration_results.csv')
-
-
-def main():
-    sample_measurements, _ = acquire_files()
-    recalibrate(sample_measurements)
-
-if __name__ == '__main__':
-    main()
+dirt_k_40_unc = 0.01
+dirt_bi_214_unc = 0.02
+dirt_pb_214_unc = 0.02
+dirt_th_234_unc = 0.07
+dirt_tl_208_unc = 0.05
+dirt_ac_228_unc = 0.07
+dirt_pb_212_unc = 0.05
+dirt_concentrations = [dirt_k_40, dirt_bi_214, dirt_pb_214, dirt_th_234,
+                       dirt_tl_208, dirt_ac_228, dirt_pb_212]
+dirt_concentrations_uncertainty = [dirt_k_40_unc, dirt_bi_214_unc,
+                                   dirt_pb_214_unc, dirt_th_234_unc,
+                                   dirt_tl_208_unc, dirt_ac_228_unc,
+                                   dirt_pb_212_unc]
+dirt_conversions = [309.6, 12.3, 4.07]
+soil_reference = base_reference_class(dirt_S5F_mass, dirt_concentrations,
+                           dirt_concentrations_uncertainty, dirt_conversions)
+petri_reference = petri_reference_class(dirt_petri_mass, dirt_concentrations,
+                           dirt_concentrations_uncertainty, dirt_conversions,
+                           petri_specific_activity)

--- a/Gamma_Reference.py
+++ b/Gamma_Reference.py
@@ -1,6 +1,4 @@
-
-
-class Reference(object):
+class base_reference_class(object):
     """
     Generates a reference object that contains a reference mass and
     concentrations. Mass is in kg and concentrations are in percent for
@@ -14,7 +12,24 @@ class Reference(object):
         self.ref_concentration_error = ref_concentration_error
         self.conversion = conversion
 
-dirt_mass = 2.380
+class petri_reference_class(base_reference_class):
+    """
+    Uses the Petri dish sample data as the reference.
+    """
+    def spec_count_rate(self, mass, ref_concentration, ref_concentration_error,
+                 conversion, ref_specific_count_rate):
+        self.ref_spec_ct_rate = ref_specific_activity
+
+# Create a list of samples that uses an alternate reference.
+alt_ref_samples = ['UCB027']
+# Define the mass for the Petri soil reference sample.
+dirt_petri_mass = 1.18360
+petri_specific_count_rate = [2.15E-01, 9.35E-03, 2.17E-02, 1.05E-02, 1.75E-02,
+                             1.56E-02, 7.27E-02, 8.28E-03, 8.56E-03, 4.11E-02,
+                             5.25E-02, 3.10E-02, 1.07E-02, 1.50E-02]
+
+# Define the mass for the S5F soil reference sample.
+dirt_S5F_mass = 1.19300
 dirt_k_40 = 2.57
 dirt_bi_214 = 1.97
 dirt_pb_214 = 1.97
@@ -37,5 +52,8 @@ dirt_concentrations_uncertainty = [dirt_k_40_unc, dirt_bi_214_unc,
                                    dirt_tl_208_unc, dirt_ac_228_unc,
                                    dirt_pb_212_unc]
 dirt_conversions = [309.6, 12.3, 4.07]
-soil_reference = Reference(dirt_mass, dirt_concentrations,
+soil_reference = base_reference_class(dirt_S5F_mass, dirt_concentrations,
                            dirt_concentrations_uncertainty, dirt_conversions)
+petri_reference = petri_reference_class(dirt_petri_mass, dirt_concentrations,
+                           dirt_concentrations_uncertainty, dirt_conversions,
+                           petri_specific_activity)

--- a/Gamma_Reference.py
+++ b/Gamma_Reference.py
@@ -1,3 +1,7 @@
+from ROI_Maker import (ROI_Maker, peak_measurement, emission_rate,
+                      background_subtract, absolute_efficiency, isotope_activity)
+import SPEFile
+
 class ReferenceBase(object):
     """
     Generates a reference object that contains a reference mass and
@@ -5,28 +9,77 @@ class ReferenceBase(object):
     K-40 and ppm for the rest. Conversions are currently unknown in their
     origin and derivation.
     """
+
+
     def __init__(self, mass, ref_concentration, ref_concentration_error,
-                 conversion):
+                 conversion, spectrum=None):
         self.mass = mass
         self.ref_concentration = ref_concentration
         self.ref_concentration_error = ref_concentration_error
         self.conversion = conversion
+        self.spectrum = spectrum
+
+
+    def get_spec_countrates(self, isotope, background):
+        reference = self.spectrum
+        ref_spec_count_rate = []
+        ref_spec_ct_rate_error = []
+
+        for energy in isotope.list_sig_g_e:
+            reference_peak = peak_measurement(reference, energy)
+            background_peak = peak_measurement(background, energy)
+            reference_area = background_subtract(reference_peak,
+                                                 background_peak,
+                                                 reference.livetime,
+                                                 background.livetime)
+            ref_spec_count_rate.append(reference_area[0]/(reference.livetime*self.mass))
+            ref_spec_ct_rate_error.append(reference_area[1]/(reference.livetime*self.mass))
+
+        return ref_spec_count_rate, ref_spec_ct_rate_error
+
+
+    def get_spec_activity(self, isotope, background):
+        spec_countrates, spec_countrates_error = self.get_spec_countrates(isotope, background=background)
+        spec_emissions = []
+        spec_emissions_error = []
+        for i, energy in enumerate(isotope.list_sig_g_e):
+            eff = absolute_efficiency([energy])[0]
+            spec_em = spec_countrates[i] / eff
+            spec_em_err = spec_countrates_error[i] / eff
+            spec_emissions.append(spec_em)
+            spec_emissions_error.append(spec_em_err)
+        act = isotope_activity(isotope, spec_emissions, spec_emissions_error)
+        return act
+
 
 class PetriReference(ReferenceBase):
     """
     Uses the Petri dish sample data as the reference.
     """
-    def spec_count_rate(self, mass, ref_concentration, ref_concentration_error,
-                 conversion, ref_specific_count_rate):
+
+    def __init__(self, ref_specific_count_rate, ref_spec_ct_rate_error,
+                 **kwargs):
         self.ref_spec_ct_rate = ref_specific_count_rate
+        self.ref_spec_ct_rate_error = ref_spec_ct_rate_error
+        ReferenceBase.__init__(self, **kwargs)
+
+    def get_spec_countrates(self, isotope, **kwargs):
+        isotope_name = isotope.symbol + str(isotope.mass_number)
+        return (self.ref_spec_ct_rate[isotope_name],
+                self.ref_spec_ct_rate_error[isotope_name])
+
 
 # Create a list of samples that uses an alternate reference.
 alt_ref_samples = ['UCB027']
 # Define the mass for the Petri soil reference sample.
 dirt_petri_mass = 1.18360
-petri_specific_count_rate = [3.11E-04, 2.15E-01, 9.35E-03, 2.17E-02, 1.05E-02,
-                             1.75E-02, 1.56E-02, 7.27E-02, 8.28E-03, 8.56E-03,
-                             4.11E-02, 5.25E-02, 3.10E-02, 1.07E-02, 1.50E-02]
+petri_specific_count_rate = {'K40': [2.15E-01],
+                             'Bi214': [8.28E-03, 8.56E-03, 4.11E-02],
+                             'Tl208': [9.35E-03, 2.17E-02]}
+
+petri_spec_ct_rate_error = {'K40': [1.55E-03],
+                             'Bi214': [3.54E-04, 4.69E-04, 8.05E-04],
+                             'Tl208': [3.96E-04, 6.59E-04]}
 
 # Define the mass for the S5F soil reference sample.
 dirt_S5F_mass = 1.19300
@@ -52,8 +105,18 @@ dirt_concentrations_uncertainty = [dirt_k_40_unc, dirt_bi_214_unc,
                                    dirt_tl_208_unc, dirt_ac_228_unc,
                                    dirt_pb_212_unc]
 dirt_conversions = [309.6, 12.3, 4.07]
-soil_reference = ReferenceBase(dirt_S5F_mass, dirt_concentrations,
-                           dirt_concentrations_uncertainty, dirt_conversions)
-petri_reference = PetriReference(dirt_petri_mass, dirt_concentrations,
+
+
+S5F_spectrum = SPEFile.SPEFile("UCB018_Soil_Sample010_2.Spe")
+S5F_spectrum.read()
+
+S5F_reference = ReferenceBase(dirt_S5F_mass, dirt_concentrations,
                            dirt_concentrations_uncertainty, dirt_conversions,
-                           petri_specific_activity)
+                           S5F_spectrum)
+petri_reference = PetriReference(
+    mass=dirt_petri_mass, 
+    ref_concentration=dirt_concentrations,
+    ref_concentration_error=dirt_concentrations_uncertainty, 
+    conversion=dirt_conversions,
+    ref_specific_count_rate=petri_specific_count_rate,
+    ref_spec_ct_rate_error=petri_spec_ct_rate_error)

--- a/ROI_Maker.py
+++ b/ROI_Maker.py
@@ -1,8 +1,8 @@
 import numpy as np
 import peakutils
 from Isotope_identification import Cs_134_g_e
-from Isotope_identification import Bi_214_g_e
 
+EFFICIENCY_CAL_COEFFS = [-5.1164, 161.65, -3952.3, 30908]
 
 def ROI_Maker(spectrum, energy, sub_regions='auto'):
     """
@@ -16,68 +16,44 @@ def ROI_Maker(spectrum, energy, sub_regions='auto'):
 
     E0 = spectrum.energy_cal[0]
     Eslope = spectrum.energy_cal[1]
+    energy_channel = int((peak_energy - E0) / Eslope)
 
-    energy_ch = int((peak_energy - E0) / Eslope)
-
-    region_size = 2.0
-    separation_parameter = 1.2
+    region_size = 1.3
+    compton_distance = 4
 
     # Rough estimate of FWHM.
-    fwhm_kev = 0.05*peak_energy**0.5
-    fwhm_ch = (fwhm_kev - E0)/Eslope
+    fwhm = 0.05*peak_energy**0.5
+    fwhm_channel = int(region_size * (fwhm - E0) / Eslope)
+    # peak gross area
+    peak_ch = (energy_channel - fwhm_channel, energy_channel + fwhm_channel)
 
-    region_half_width = int(region_size * fwhm_ch)
-    region_separation = int(separation_parameter*fwhm_ch)
+    left_center = energy_channel - compton_distance * fwhm_channel
+    left_ch = (left_center - fwhm_channel, left_center + fwhm_channel)
 
-    peak_ch = (energy_ch - region_half_width, energy_ch + region_half_width)
-
-    left_ch = (energy_ch - region_separation - 3*region_half_width,
-               energy_ch - region_separation - region_half_width)
-
-    right_ch = (energy_ch + region_separation + region_half_width,
-                energy_ch + region_separation + 3*region_half_width)
+    right_center = energy_channel + compton_distance * fwhm_channel
+    right_ch = (right_center - fwhm_channel, right_center + fwhm_channel)
 
     if sub_regions == 'auto':
         if energy == Cs_134_g_e[2]:
             sub_regions = 'Cs134'
-        elif energy == Bi_214_g_e[0]:
-            sub_regions = 'Bi214'
         else:
             sub_regions = 'both'
 
     if sub_regions == 'left':
         side_region_list = [left_ch]
-
     elif sub_regions == 'right':
         side_region_list = [right_ch]
-
     elif sub_regions == 'Cs134':
         # Cs134 compton region using Bi214 609 peak.
-        bi_fwhm_kev = 0.05 * (609.31)**0.5
-        bi_fwhm_ch = (bi_fwhm_kev - E0)/Eslope
-        bi_region_half_width = int(region_size * bi_fwhm_ch)
-        bi_region_separation = int(separation_parameter*bi_fwhm_ch)
-        bi_energy_ch = int((609.31 - E0) / Eslope)
-        bi_right_ch = (
-            bi_energy_ch + bi_region_separation + bi_region_half_width,
-            bi_energy_ch + bi_region_separation + 3*bi_region_half_width)
+        bi_fwhm = 0.05 * (609.31)**0.5
+        bi_fwhm_channel = int(region_size * (bi_fwhm - E0) / Eslope)
+        bi_peak_channel = int((609.31 - E0) / Eslope)
+        bi_right_peak = bi_peak_channel + compton_distance * bi_fwhm_channel
+        bi_right_ch = (bi_right_peak - fwhm_channel,
+                       bi_right_peak + fwhm_channel)
         side_region_list = [left_ch, bi_right_ch]
-
-    elif sub_regions == 'Bi214':
-        # Bi214 compton region using Cs134 604 peak.
-        cs_fwhm_kev = 0.05 * (604.72)**0.5
-        cs_fwhm_ch = (cs_fwhm_kev - E0)/Eslope
-        cs_region_half_width = int(region_size*cs_fwhm_ch)
-        cs_region_separation = int(separation_parameter*cs_fwhm_ch)
-        cs_energy_ch = int((604.72 - E0) / Eslope)
-        cs_left_ch = (
-            cs_energy_ch - cs_region_separation - 3*cs_region_half_width,
-            cs_energy_ch - cs_region_separation - cs_region_half_width)
-        side_region_list = [cs_left_ch, right_ch]
-
     elif sub_regions == 'none':
         side_region_list = []
-
     else:
         side_region_list = [left_ch, right_ch]
 
@@ -117,3 +93,111 @@ def peak_finder(spectrum, energy):
         peak_energy.append(int(indexes+start_region))
     peak_energy = float(energy_axis[peak_energy])
     return(peak_energy)
+
+def peak_measurement(M, energy, sub_regions='auto'):
+    """
+    Takes in a measured spectra alongside a specific energy and returns the net
+    area and uncertainty (2-sigma) for that energy.
+    """
+
+    peak_ch, side_ch_list = ROI_Maker(M, energy, sub_regions=sub_regions)
+    gross_area_peak = sum(M.data[peak_ch[0]:peak_ch[1]])
+    n_compton = len(side_ch_list)
+
+    if n_compton == 0:
+        compton_area = 0
+        compton_area_unc = 0
+    elif n_compton == 1:
+        compton_ch = side_ch_list[0]
+        compton_area = M.data[compton_ch[0]:compton_ch[1]]
+        compton_area_unc = np.sqrt(compton_area)
+    elif n_compton == 2:
+        compton_1 = side_ch_list[0]
+        compton_2 = side_ch_list[1]
+        compton_area_1 = sum(M.data[compton_1[0]:compton_1[1]])
+        compton_area_2 = sum(M.data[compton_2[0]:compton_2[1]])
+        compton_area = np.mean([compton_area_1, compton_area_2])
+        # compton_area_1_unc = sqrt(compton_area_1)
+        # propagate uncertainty for taking the mean: /2
+        compton_area_unc = np.sqrt(compton_area_1 + compton_area_2) / 2
+
+    net_area = gross_area_peak - compton_area
+    net_area_unc = np.sqrt(gross_area_peak + compton_area_unc**2)
+
+    # 2 sigma uncertainty
+    return net_area, 2 * net_area_unc
+
+def emission_rate(net_area, efficiency, livetime):
+    """
+    this function returns the emission rate of gammas per second
+    alongside its uncertainty.
+    """
+    emission_rate = [net_area[0]/(efficiency*livetime),
+                     net_area[1]/(efficiency*livetime)]
+    return emission_rate
+
+def background_subtract(meas_area, back_area, meas_time, back_time):
+    """
+    Background_Subtract will subtract a measured Background peak net area from
+    a sample peak net area. The background peak is converted to the same time
+    scale as the measurement and the subtraction is performed. All inputs are
+    scalar numbers, where Meas_Area and Back_Area represent the net area of
+    a sample net area and background net area respectively. Meas_Time and
+    Back_Time are the livetimes of the measurement and background respectively.
+    """
+
+    time_ratio = meas_time / back_time
+    back_to_meas = back_area[0] * time_ratio
+    meas_sub_back = meas_area[0] - back_to_meas
+
+    meas_uncertainty = meas_area[1]
+    back_uncertainty = back_area[1] * time_ratio
+    meas_sub_back_uncertainty = (meas_uncertainty**2 +
+                                 back_uncertainty**2)**0.5
+
+    sub_peak = [meas_sub_back, meas_sub_back_uncertainty]
+    return sub_peak
+
+def absolute_efficiency(energy, coeffs=EFFICIENCY_CAL_COEFFS):
+    """
+    Returns absolute efficiencies for a given set of energies, based on a
+    provided efficiency calibration. It takes an energy (in keV) and a set
+    of calibration coefficients.
+    The efficiency is calculated using the equation given below:
+    ln(efficiency) = c3*(E^3) + c2*(E^2) + c1*E + c0*E,
+    where E = ln(energy[keV])/energy[keV]
+    """
+    efficiency = []
+    for i in range(len(energy)):
+        efficiency.append(np.exp(coeffs[3] *
+                          (np.log(energy[i])/energy[i])**3 +
+                          coeffs[2]*(np.log(energy[i])/energy[i])**2 +
+                          coeffs[1]*(np.log(energy[i])/energy[i]) +
+                          coeffs[0]))
+    return efficiency
+
+def isotope_activity(isotope, emission_rates, emission_uncertainty):
+    """
+    Isotope_Activity will determine the activity of a given radioactive isotope
+    based on the emission rates given and the isotope properties. It takes an
+    Isotope object and a given set of emission rates and outputs an activity
+    estimate alongside its uncertainty.
+    """
+    branching_ratio = isotope.list_sig_g_b_r
+    activity = []
+    uncertainty = []
+    weight = []
+    squares_total = []
+    for i in range(len(branching_ratio)):
+        activity.append(emission_rates[i]/branching_ratio[i])
+        uncertainty.append(emission_uncertainty[i]/branching_ratio[i])
+        weight.append(1/(emission_uncertainty[i]/branching_ratio[i])**2)
+        squares_unc = uncertainty[i]**2 * weight[i]**2
+        squares_total.append(squares_unc)
+    sum_of_squares = np.sum(squares_total)
+    V_1 = np.sum(weight)
+    weighted_avg_isotope_activity = np.sum(
+        np.array(activity) * np.array(weight)) / V_1
+    weighted_avg_isotope_unc = sum_of_squares**0.5 / V_1
+    results = [weighted_avg_isotope_activity, weighted_avg_isotope_unc]
+    return results

--- a/calibrate.py
+++ b/calibrate.py
@@ -30,14 +30,12 @@ def acquire_files():
             else:
                 if '_recal' in file:
                     f.append(file)
-                    f[-1].replace('_recal.Spe', '.Spe')
-
                 sample_measurements.append(file)
 
     sample_measurements.sort()
 
     for i in np.arange(len(f)):
-        sample_measurements.remove(f[i])
+        sample_measurements.remove(f[i].replace('_recal', ''))
 
     sample_names = [os.path.splitext(sample_measurements[i])[0]
                     .replace("_", " ") for i in np

--- a/calibrate.py
+++ b/calibrate.py
@@ -19,8 +19,8 @@ def acquire_files():
     sample_measurements = []
     sample_names = []
     f = []
+    s = []
     dir_path = os.getcwd()
-    skip_file = ''
     for file in os.listdir(dir_path):
         if file.lower().endswith(".spe"):
             # Ignore the background and reference spectra
@@ -30,15 +30,16 @@ def acquire_files():
                 pass
             else:
                 if '_recal' in file:
-                    f.append(file)
-                    f[-1].replace('_recal.Spe', '.Spe')
+                    s = file
+                    s.replace('_recal.Spe', '.Spe')
+                    f.append(s)
 
                 sample_measurements.append(file)
                 sample_names.append(file)
 
-    for file in os.listdir(dir_path):
-        if file == f:
-            os.remove(file)
+    for i in np.arange(len(f)):
+        os.remove(f[i])
+        f.remove(f[i])
 
     sample_measurements.sort()
     sample_names.sort()

--- a/calibrate.py
+++ b/calibrate.py
@@ -27,14 +27,18 @@ def acquire_files():
             elif filename == "UCB018_Soil_Sample010_2.Spe":
                 pass
             else:
-                if '_recal.spe' in filename:
+                if '_recal.Spe' in filename:
                     recal_names.append(filename)
                 sample_measurements.append(filename)
 
     sample_measurements.sort()
 
+    print("recal_names: ", recal_names, '\n\n')
+
     for recal_name in recal_names:
         recal_focus = recal_name.replace('_recal', '')
+
+        print(recal_focus)
 
         if recal_focus in sample_measurements:
             sample_measurements.remove(recal_focus)
@@ -42,6 +46,9 @@ def acquire_files():
     sample_names = [os.path.splitext(sample_measurements[i])
                     [0].replace("_", " ")
                     for i in np.arange(len(sample_measurements))]
+
+    print("sample_names: ", sample_names, '\n\n')
+    print("sample_measurements: ", sample_measurements, '\n\n')
 
     return sample_measurements, sample_names
 
@@ -139,7 +146,7 @@ def recalibrate(files):
     cal_offsets = []
 
     for sample in files:
-        if '_recal.spe' in sample.lower():
+        if '_recal.Spe' in sample.lower():
             double_check.append(sample)
             pass
         else:
@@ -166,11 +173,15 @@ def recalibrate(files):
         with open('Error_Cal.txt', 'w') as file:
             file.writelines('Check calibration in %s \n' % error for error in
                             cal_error)
-    for file in files:
-        if '_recal.Spe' in file:
-            files.remove(file)
+    # for file in files:
+    #     if '_recal.Spe' in file:
+    #         files.remove(file)
 
-    calibration_table(files, cal_headers, cal_offsets)
+    files_updated = [os.path.splitext(files[i])
+                     [0].replace("_recal", "")
+                     for i in np.arange(len(files))]
+
+    calibration_table(files_updated, cal_headers, cal_offsets)
 
 
 def calibration_table(samples, headers, offsets):
@@ -184,12 +195,7 @@ def calibration_table(samples, headers, offsets):
     cal_frame = cal_frame.T
     cal_frame.index.name = 'Filename'
     cal_frame.to_csv('calibration_results.csv')
-    
-def get_sample_names(sample_measurements):
-    sample_names = [os.path.splitext(sample_measurements[i])
-                   [0].replace("_", " ")
-                   for i in np.arange(len(sample_measurements))]
-    return sample_names
+
 
 def main():
     sample_measurements, _ = acquire_files()

--- a/calibrate.py
+++ b/calibrate.py
@@ -17,29 +17,31 @@ def acquire_files():
     returns a list containing all .Spe files.
     """
     sample_measurements = []
-    sample_names = []
-    f = []
+    recal_names = []
     dir_path = os.getcwd()
-    for file in os.listdir(dir_path):
-        if file.lower().endswith(".spe"):
+    for filename in os.listdir(dir_path):
+        if filename.lower().endswith(".spe"):
             # Ignore the background and reference spectra
-            if file == "USS_Independence_Background.Spe":
+            if filename == "USS_Independence_Background.Spe":
                 pass
-            elif file == "UCB018_Soil_Sample010_2.Spe":
+            elif filename == "UCB018_Soil_Sample010_2.Spe":
                 pass
             else:
-                if '_recal' in file:
-                    f.append(file)
-                sample_measurements.append(file)
+                if '_recal' in filename:
+                    recal_names.append(filename)
+                sample_measurements.append(filename)
 
     sample_measurements.sort()
 
-    for i in np.arange(len(f)):
-        sample_measurements.remove(f[i].replace('_recal', ''))
+    for i in np.arange(len(recal_names)):
+        recal_focus = recal_names[i].replace('_recal', '')
 
-    sample_names = [os.path.splitext(sample_measurements[i])[0]
-                    .replace("_", " ") for i in np
-                    .arange(len(sample_measurements))]
+        if recal_focus in sample_measurements:
+            sample_measurements.remove(recal_focus)
+
+    sample_names = [os.path.splitext(sample_measurements[i])
+                    [0].replace("_", " ")
+                    for i in np.arange(len(sample_measurements))]
 
     return sample_measurements, sample_names
 

--- a/calibrate.py
+++ b/calibrate.py
@@ -33,8 +33,8 @@ def acquire_files():
 
     sample_measurements.sort()
 
-    for i in np.arange(len(recal_names)):
-        recal_focus = recal_names[i].replace('_recal', '')
+    for recal_name in recal_names:
+        recal_focus = recal_name.replace('_recal', '')
 
         if recal_focus in sample_measurements:
             sample_measurements.remove(recal_focus)

--- a/calibrate.py
+++ b/calibrate.py
@@ -27,7 +27,7 @@ def acquire_files():
             elif filename == "UCB018_Soil_Sample010_2.Spe":
                 pass
             else:
-                if '_recal' in filename:
+                if '_recal.spe' in filename:
                     recal_names.append(filename)
                 sample_measurements.append(filename)
 
@@ -166,6 +166,10 @@ def recalibrate(files):
         with open('Error_Cal.txt', 'w') as file:
             file.writelines('Check calibration in %s \n' % error for error in
                             cal_error)
+    for file in files:
+        if '_recal.Spe' in file:
+            files.remove(file)
+
     calibration_table(files, cal_headers, cal_offsets)
 
 
@@ -173,7 +177,9 @@ def calibration_table(samples, headers, offsets):
 
     cal_results = {}
     for i in range(len(samples)):
+
         cal_results[samples[i]] = np.array(offsets[i])
+
     cal_frame = pd.DataFrame(cal_results, index=headers)
     cal_frame = cal_frame.T
     cal_frame.index.name = 'Filename'

--- a/calibrate.py
+++ b/calibrate.py
@@ -19,7 +19,6 @@ def acquire_files():
     sample_measurements = []
     sample_names = []
     f = []
-    s = []
     dir_path = os.getcwd()
     for file in os.listdir(dir_path):
         if file.lower().endswith(".spe"):
@@ -30,23 +29,19 @@ def acquire_files():
                 pass
             else:
                 if '_recal' in file:
-                    s = file
-                    s.replace('_recal.Spe', '.Spe')
-                    f.append(s)
+                    f.append(file)
+                    f[-1].replace('_recal.Spe', '.Spe')
 
                 sample_measurements.append(file)
-                sample_names.append(file)
-
-    for i in np.arange(len(f)):
-        os.remove(f[i])
-        f.remove(f[i])
 
     sample_measurements.sort()
-    sample_names.sort()
 
     for i in np.arange(len(f)):
-        sample_names = [os.path.splitext(f[i])[0].replace("_", " ")
-                        for f[i] in sample_measurements]
+        sample_measurements.remove(f[i])
+
+    sample_names = [os.path.splitext(sample_measurements[i])[0]
+                    .replace("_", " ") for i in np
+                    .arange(len(sample_measurements))]
 
     return sample_measurements, sample_names
 


### PR DESCRIPTION
Hi Brian,

The recent commits are for both the `recalibrate()` and Sea Salt issues. The changes I've made are as follows:

**`calibrate.py`:** In the `recalibrate()` function, the `_recal` identifier is removed from every element containing it from essentially the `sample_measurements` object (called `files` in `recalibrate()`) before being passed into the `calibration_table` function. Also, I've fixed the capitalization in the check for `_recal.Spe` which may or may not have been an issue in the original code. Now I think the functionality is solid for the `recalibrate()` function, but a new issue has appeared: A "peak not found" error is issued by `calibration_check()`. I need help with this error because the peak finding is a more technical aspect of the code, and it's part of the changes that need to be made (see **Required Changes** below).

**`Gamma_Reference.py`:** Renamed the `Reference()` class into `base_reference_class()`. Created an inherited class `petri_reference_class()` that adds the specific count rate as an attribute `ref_spec_ct_rate`, while preserving the reference mass, concentration, concentration error, and conversion attributes. Created a specific count rate list `petri_specific_count_rate` that is pulled from elements N2-N19 from the `UCB018 Loc010 (reference) Petri` Google sheet. Created a list of samples names that require the use of the Petri reference. Created a separate soil mass for the Petri reference and renamed the old S5F soil mass reference. Changed the use of the S6F soil mass to the S5F soil mass as taken from the associated Google Sheets. Created a `petri_reference` attribute of `Gamma_Reference.py` that creates an instance of `petri_reference_class()` and inputs the Petri reference mass, concentration, concentration error, conversion, and specific count rate array.

**`Gamma_Analysis.py`:** In the `main()` function, assigned the S5F reference by default. Added a check if the sample uses the Petri reference, if so it assigns the specific activity attribute of `petri_reference` in place of the `UCB018_Soil_Sample010_2.Spe` spectrum. In the `analyze_isotope()` method, added a check if the reference is of type `base_reference_class()` or `petri_reference_class()` and if so assigns the `soil_reference` or `petri_reference` attributes of `Gamma_Reference.py` as the reference object for mass, concentration, concentration error, and conversion (and specific count rate in the case of the Petri reference). Added the same check when the code finds the reference peak, peak area, emission, emission uncertainty, and activity. The usual method is used if the reference object is the S5F reference class, and a simple assignment of the `ref_spec_ct_rate` attribute of `petri_reference` is done if the reference object is the Petri reference class. Either way, the `reference_activity` and `sample_comparison` objects are input into the `isotope_concentration` method. In `isotope_concentration`, I've added the check of reference objects, but there is no functionality (see **Required Changes** below). One additional change is the removal of the input of the detector efficiency into `emission_rate()` function and the use of it in that function. We should keep the `absolute_efficiency()` function in case we need it in the future, but currently the code does not need it.

**Required changes:** In `Gamma_Reference.py`, there needs to be a list of the which isotopes each element of `petri_specific_count_rate` refers to and an attribute for an isotope list can be added to it. This can play into the idea of having a dict for the isotope references in `isotope_concentration()`. I think the major issue in `analyze_isotope()` is that it calls on `isotope_activity()` to find a weighted average of the isotope activity based on the emission rate array input into it, which becomes a problem for the Petri reference since we only have the specific count rate for each peak. So I need help breaking the `petri_specific_count_rate` list based on which isotope each peak energy belongs to and help with either creating an emission rate array for the Petri reference or finding the weighted average of the specific count rate for each isotope in the Petri reference and inputting that into the `isotope_concentration()` function. I need help with the "peak not found" issue for the `recalibrate()` issue as well.